### PR TITLE
Dont allocate on new

### DIFF
--- a/benches/comparisons.rs
+++ b/benches/comparisons.rs
@@ -9,6 +9,18 @@ use dynstack::{DynStack, dyn_push};
 
 use std::fmt::Display;
 
+trait ATrait {}
+
+struct Large([u8; 950]);
+
+impl Large {
+    pub fn new() -> Self {
+        Self([3; 950])
+    }
+}
+
+impl ATrait for Large {}
+
 fn new_speed_naive(b: &mut Bencher) {
     b.iter(|| {
         Vec::<Box<dyn Display>>::new()
@@ -18,6 +30,22 @@ fn new_speed_naive(b: &mut Bencher) {
 fn new_speed_dynstack(b: &mut Bencher) {
     b.iter(|| {
         DynStack::<dyn Display>::new()
+    });
+}
+
+fn push_large_speed_naive(b: &mut Bencher) {
+    b.iter(|| {
+        let mut vec = Vec::<Box<dyn ATrait>>::new();
+        vec.push(Box::new(Large::new()));
+        vec
+    });
+}
+
+fn push_large_speed_dynstack(b: &mut Bencher) {
+    b.iter(|| {
+        let mut stack = DynStack::<dyn ATrait>::new();
+        dyn_push!(stack, Large::new());
+        stack
     });
 }
 
@@ -109,6 +137,8 @@ fn pseudorecursive2_dynstack(b: &mut Bencher) {
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("new_speed_naive", new_speed_naive);
     c.bench_function("new_speed_dynstack", new_speed_dynstack);
+    c.bench_function("push_large_speed_naive", push_large_speed_naive);
+    c.bench_function("push_large_speed_dynstack", push_large_speed_dynstack);
     c.bench_function("push_speed_naive", push_speed_naive);
     c.bench_function("push_speed_dynstack", push_speed_dynstack);
     c.bench_function("push_and_run_naive", push_and_run_naive);

--- a/benches/comparisons.rs
+++ b/benches/comparisons.rs
@@ -9,6 +9,18 @@ use dynstack::{DynStack, dyn_push};
 
 use std::fmt::Display;
 
+fn new_speed_naive(b: &mut Bencher) {
+    b.iter(|| {
+        Vec::<Box<dyn Display>>::new()
+    });
+}
+
+fn new_speed_dynstack(b: &mut Bencher) {
+    b.iter(|| {
+        DynStack::<dyn Display>::new()
+    });
+}
+
 fn push_speed_naive(b: &mut Bencher) {
     let mut vec = Vec::<Box<Display>>::new();
     b.iter(|| {
@@ -95,6 +107,8 @@ fn pseudorecursive2_dynstack(b: &mut Bencher) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("new_speed_naive", new_speed_naive);
+    c.bench_function("new_speed_dynstack", new_speed_dynstack);
     c.bench_function("push_speed_naive", push_speed_naive);
     c.bench_function("push_speed_dynstack", push_speed_dynstack);
     c.bench_function("push_and_run_naive", push_and_run_naive);


### PR DESCRIPTION
I created benchmarks for measuring creating new vectors/dynstacks. The standard `Vec` type outperformed `DynStack` with 2 ns vs 43 ns. Ouch.

`Vec::new()` promises it does not perform any allocation. Instead that is done when the first element is pushed (or if constructed with `Vec::with_capacity(x)`). So I thought we should do the same here.

With this PR the `new_speed_dynstack` benchmark goes from 43 to 4.5 ns on my machine. 89% less time. All other benchmarks remain unchanged for me.