### PR TITLE
Upgrade crate to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A stack for trait objects that minimizes allocations"
 repository = "https://github.com/archshift/dynstack"
 license = "MIT"
 readme = "README.md"
+edition = "2018"
 
 [dev-dependencies]
 criterion = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ it isn't expected to change in the foreseeable future, this crate expects Rust 1
 require removal from its center.
 
 ```rust
-let mut stack = DynStack::<Debug>::new();
+let mut stack = DynStack::<dyn Debug>::new();
 dyn_push!(stack, "hello, world!");
 dyn_push!(stack, 0usize);
 dyn_push!(stack, [1, 2, 3, 4, 5, 6]);

--- a/benches/comparisons.rs
+++ b/benches/comparisons.rs
@@ -1,12 +1,5 @@
-#[macro_use]
-extern crate criterion;
-extern crate dynstack;
-
-use criterion::Bencher;
-use criterion::Criterion;
-
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use dynstack::{DynStack, dyn_push};
-
 use std::fmt::Display;
 
 trait ATrait {}

--- a/benches/comparisons.rs
+++ b/benches/comparisons.rs
@@ -50,7 +50,7 @@ fn push_large_speed_dynstack(b: &mut Bencher) {
 }
 
 fn push_speed_naive(b: &mut Bencher) {
-    let mut vec = Vec::<Box<Display>>::new();
+    let mut vec = Vec::<Box<dyn Display>>::new();
     b.iter(|| {
         vec.push(Box::new(0xF00BAAusize));
         vec.push(Box::new(0xABBAu16));
@@ -60,7 +60,7 @@ fn push_speed_naive(b: &mut Bencher) {
 }
 
 fn push_speed_dynstack(b: &mut Bencher) {
-    let mut stack = DynStack::<Display>::new();
+    let mut stack = DynStack::<dyn Display>::new();
     b.iter(|| {
         dyn_push!(stack, 0xF00BAAusize);
         dyn_push!(stack, 0xABBAu16);
@@ -71,8 +71,8 @@ fn push_speed_dynstack(b: &mut Bencher) {
 
 fn push_and_run_naive(b: &mut Bencher) {
     b.iter(|| {
-        let mut stack = Vec::<Box<Fn() -> usize>>::new();
-        fn pseudorecursive(stack: &mut Vec<Box<Fn() -> usize>>, n: usize) {
+        let mut stack = Vec::<Box<dyn Fn() -> usize>>::new();
+        fn pseudorecursive(stack: &mut Vec<Box<dyn Fn() -> usize>>, n: usize) {
             stack.push(Box::new(move || n - 1));
         }
 
@@ -88,8 +88,8 @@ fn push_and_run_naive(b: &mut Bencher) {
 
 fn push_and_run_dynstack(b: &mut Bencher) {
     b.iter(|| {
-        let mut stack = DynStack::<Fn() -> usize>::new();
-        fn pseudorecursive(stack: &mut DynStack<Fn() -> usize>, n: usize) {
+        let mut stack = DynStack::<dyn Fn() -> usize>::new();
+        fn pseudorecursive(stack: &mut DynStack<dyn Fn() -> usize>, n: usize) {
             dyn_push!(stack, move || n - 1);
         }
 
@@ -105,8 +105,8 @@ fn push_and_run_dynstack(b: &mut Bencher) {
 
 fn pseudorecursive2_naive(b: &mut Bencher) {
     b.iter(|| {
-        let mut state: Box<Fn() -> usize> = Box::new(|| 0);
-        fn pseudorecursive(state: &mut Box<Fn() -> usize>, n: usize) {
+        let mut state: Box<dyn Fn() -> usize> = Box::new(|| 0);
+        fn pseudorecursive(state: &mut Box<dyn Fn() -> usize>, n: usize) {
             *state = Box::new(move || n - 1);
         }
 
@@ -120,8 +120,8 @@ fn pseudorecursive2_naive(b: &mut Bencher) {
 
 fn pseudorecursive2_dynstack(b: &mut Bencher) {
     b.iter(|| {
-        let mut stack = DynStack::<Fn() -> usize>::new();
-        fn pseudorecursive(stack: &mut DynStack<Fn() -> usize>, n: usize) {
+        let mut stack = DynStack::<dyn Fn() -> usize>::new();
+        fn pseudorecursive(stack: &mut DynStack<dyn Fn() -> usize>, n: usize) {
             dyn_push!(stack, move || n - 1);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! //  [1, 2, 3, 4, 5, 6]
 //! ```
 
-
+#![deny(rust_2018_idioms)]
 
 use std::alloc::{alloc, dealloc, Layout};
 use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,13 @@
 
 #![deny(rust_2018_idioms)]
 
-use std::alloc::{alloc, dealloc, Layout};
-use std::mem;
-use std::marker::PhantomData;
-use std::ptr;
-use std::ops::{Index, IndexMut};
-
-
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    marker::PhantomData,
+    mem,
+    ops::{Index, IndexMut},
+    ptr,
+};
 
 /// Decompose a fat pointer into its constituent [pointer, extdata] pair
 unsafe fn decomp_fat<T: ?Sized>(ptr: *const T) -> [usize; 2] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ```
 //! # use dynstack::{DynStack, dyn_push};
 //! # use std::fmt::Debug;
-//! let mut stack = DynStack::<Debug>::new();
+//! let mut stack = DynStack::<dyn Debug>::new();
 //! dyn_push!(stack, "hello, world!");
 //! dyn_push!(stack, 0usize);
 //! dyn_push!(stack, [1, 2, 3, 4, 5, 6]);
@@ -74,7 +74,7 @@ fn test_align_up() {
 
 
 /// Iterator over trait object references
-pub struct DynStackIter<'a, T: 'a + ?Sized> {
+pub struct DynStackIter<'a, T: ?Sized> {
     stack: &'a DynStack<T>,
     index: usize,
 }
@@ -89,7 +89,7 @@ impl<'a, T: 'a + ?Sized> Iterator for DynStackIter<'a, T> {
 
 
 /// Iterator over mutable trait object references
-pub struct DynStackIterMut<'a, T: 'a + ?Sized> {
+pub struct DynStackIterMut<'a, T: ?Sized> {
     stack: *mut DynStack<T>,
     index: usize,
     _spooky: PhantomData<&'a mut DynStack<T>>
@@ -381,7 +381,7 @@ macro_rules! dyn_push {
 #[test]
 fn test_push_pop() {
     use std::fmt::Debug;
-    let mut stack = DynStack::<Debug>::new();
+    let mut stack = DynStack::<dyn Debug>::new();
     let bunch = vec![1u32, 2, 3, 4, 5, 6, 7, 8, 9];
     dyn_push!(stack, 1u8);
     dyn_push!(stack, 1u32);
@@ -421,7 +421,7 @@ fn test_push_pop() {
 
 #[test]
 fn test_fn() {
-    let mut stack = DynStack::<Fn() -> usize>::new();
+    let mut stack = DynStack::<dyn Fn() -> usize>::new();
     for i in 0..100 {
         dyn_push!(stack, move || i);
     }
@@ -452,7 +452,7 @@ fn test_drop() {
     }
 
     {
-        let mut stack = DynStack::<Any>::new();
+        let mut stack = DynStack::<dyn Any>::new();
         dyn_push!(stack, Droppable{counter: 1});
         dyn_push!(stack, Droppable{counter: 2});
         dyn_push!(stack, Droppable{counter: 3});
@@ -509,14 +509,14 @@ fn test_align() {
         Aligned64 { _dat: dat }
     }
 
-    let assert_aligned = |item: &Aligned| {
-        let thin_ptr = item as *const Aligned as *const () as usize;
+    let assert_aligned = |item: &dyn Aligned| {
+        let thin_ptr = item as *const dyn Aligned as *const () as usize;
         println!("item expects alignment {}, got offset {}", item.alignment(),
             thin_ptr & (item.alignment() - 1));
         assert!(thin_ptr & (item.alignment() - 1) == 0);
     };
     
-    let mut stack = DynStack::<Aligned>::new();
+    let mut stack = DynStack::<dyn Aligned>::new();
     
     dyn_push!(stack, new32());
     dyn_push!(stack, new64());


### PR DESCRIPTION
I think this crate is a prime example of when the `dyn` keyword shines. `DynStack<T>` is quite unclear what `T` is and that it has to be a trait for it to not panic. However `DynStack<dyn T>` makes that so much clearer.