### PR TITLE
Implement Send and Sync for DynStack if T is Send/Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Don't allocate memory in `DynStack::new`. Postpone allocation until the first push.
 - Upgrade the crate to Rust 2018 edition. Makes the minimum required compiler version 1.31.
+- Implement `Send` and/or `Sync` for `DynStack<T>` if `T` is `Send`/`Sync`.
 
 
 ## [0.3.0] - 2019-04-24


### PR DESCRIPTION
I think it would be safe for the stack to be `Send` and `Sync` if the stored types are, respectively. Or can you see any problems with this?