### PR TITLE
Add a const fn new_unchecked for static initialization of stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't allocate memory in `DynStack::new`. Postpone allocation until the first push.
 - Upgrade the crate to Rust 2018 edition. Makes the minimum required compiler version 1.31.
 - Implement `Send` and/or `Sync` for `DynStack<T>` if `T` is `Send`/`Sync`.
+- Add a `const fn`, `DynStack::new_unchecked`. Allows static initalization.
 
 
 ## [0.3.0] - 2019-04-24


### PR DESCRIPTION
The only part of `DynStack::new` that could not be a `const fn` was the sanity check. So we can add an `unsafe` version of the constructor that allows static initialization.