### PR TITLE
Reuse one implementation of compose/decompose fat ptrs

### DIFF
--- a/src/fatptr.rs
+++ b/src/fatptr.rs
@@ -1,0 +1,21 @@
+/// Decompose a fat pointer into its constituent [pointer, extdata] pair
+///
+/// # Safety
+///
+/// Must only be called with the generic, `T`, being a trait object.
+pub unsafe fn decomp<T: ?Sized>(ptr: *const T) -> [usize; 2] {
+    let ptr_ref: *const *const T = &ptr;
+    let decomp_ref = ptr_ref as *const [usize; 2];
+    *decomp_ref
+}
+
+/// Recompose a fat pointer from its constituent [pointer, extdata] pair
+///
+/// # Safety
+///
+/// Must only be called with the generic, `T`, being a trait object.
+pub unsafe fn recomp<T: ?Sized>(components: [usize; 2]) -> *mut T {
+    let component_ref: *const [usize; 2] = &components;
+    let ptr_ref = component_ref as *const *mut T;
+    *ptr_ref
+}


### PR DESCRIPTION
I realize it would be very easy to reuse the same `decomp_fat` and `recomp_fat` implementations, instead of duplicating them. Reduces the risk of them becoming out of sync and one being wrong. As well as less code to understand for the confused reader.

I got rid of `recomp` and renamed `recomp_mut` to `recomp`. Since a `*mut` pointer automatically coerce to a `*const` if needed, only the version returning `*mut T` was really needed.