### PR TITLE
Add support for building without the standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add support for building without the standard library.
+- Add a `const fn`, `DynStack::new_unchecked`. Allows static initialization. This makes the
+  minimum required compiler version 1.39.
 
 ### Changed
 - Don't allocate memory in `DynStack::new`. Postpone allocation until the first push.
-- Upgrade the crate to Rust 2018 edition. Makes the minimum required compiler version 1.31.
+- Upgrade the crate to Rust 2018 edition.
 - Implement `Send` and/or `Sync` for `DynStack<T>` if `T` is `Send`/`Sync`.
-- Add a `const fn`, `DynStack::new_unchecked`. Allows static initalization.
 
 
 ## [0.3.0] - 2019-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Add support for building without the standard library.
+
 ### Changed
 - Don't allocate memory in `DynStack::new`. Postpone allocation until the first push.
 - Upgrade the crate to Rust 2018 edition. Makes the minimum required compiler version 1.31.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ criterion = "0.1.2"
 [[bench]]
 name = "comparisons"
 harness = false
+
+[features]
+default = ["std"]
+
+# Enables std. Currently used to make tests work. But the library itself
+# works without the standard library.
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,16 @@
 //! //  [1, 2, 3, 4, 5, 6]
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(rust_2018_idioms)]
 
-use std::{
+extern crate alloc;
+
+use alloc::{
     alloc::{alloc, dealloc, Layout},
+    vec::Vec,
+};
+use core::{
     marker::PhantomData,
     mem,
     ops::{Index, IndexMut},
@@ -208,7 +214,7 @@ impl<T: ?Sized> DynStack<T> {
 
     #[cfg(not(test))]
     fn reallocate(&mut self, new_cap: usize) {
-        use std::alloc::realloc;
+        use alloc::alloc::realloc;
         self.dyn_cap = new_cap;
         self.dyn_data = unsafe { realloc(self.dyn_data, self.layout(), self.dyn_cap) };
     }
@@ -407,7 +413,7 @@ macro_rules! dyn_push {
         let mut t = $item;
 
         unsafe { $stack.push(&mut t) };
-        ::std::mem::forget(t);
+        core::mem::forget(t);
     }}
 }
 
@@ -470,7 +476,7 @@ fn test_fn() {
 
 #[test]
 fn test_drop() {
-    use std::any::Any;
+    use core::any::Any;
     use std::collections::HashSet;
 
     static mut DROP_NUM: Option<HashSet<usize>> = None;
@@ -507,10 +513,10 @@ fn test_align() {
         fn alignment(&self) -> usize;
     }
     impl Aligned for u32 {
-        fn alignment(&self) -> usize { ::std::mem::align_of::<Self>() }
+        fn alignment(&self) -> usize { core::mem::align_of::<Self>() }
     }
     impl Aligned for u64 {
-        fn alignment(&self) -> usize { ::std::mem::align_of::<Self>() }
+        fn alignment(&self) -> usize { core::mem::align_of::<Self>() }
     }
 
     #[repr(align(32))]
@@ -518,7 +524,7 @@ fn test_align() {
         _dat: [u8; 32]
     }
     impl Aligned for Aligned32 {
-        fn alignment(&self) -> usize { ::std::mem::align_of::<Self>() }
+        fn alignment(&self) -> usize { core::mem::align_of::<Self>() }
     }
 
     #[repr(align(64))]
@@ -526,7 +532,7 @@ fn test_align() {
         _dat: [u8; 64]
     }
     impl Aligned for Aligned64 {
-        fn alignment(&self) -> usize { ::std::mem::align_of::<Self>() }
+        fn alignment(&self) -> usize { core::mem::align_of::<Self>() }
     }
 
     fn new32() -> Aligned32 {


### PR DESCRIPTION
The heap allocation parts of the standard library were moved to a separate, smaller `alloc` crate in Rust 1.36. In order to allow more crates to become `no_std`. This library uses no part of `std` that is not present in either `core` or `alloc` so we can broaden the usability of this crate by allowing it to be used in `no_std` projects, such as embedded etc.

I realized the usage of the `alloc` crate would mean a bump in the MSRV (minimum supported Rust version) to 1.36. But upon testing that I found out that our recently merged usage of `Vec::new` in a const context (#10) already forced us to use the very latest stable, 1.39. So I updated the changelog accordingly.

Sorry for the influx of PRs. I just randomly got some inspiration and found a bunch of stuff I wanted to improve here. I have a couple of more ideas I want to play with in the coming days. But after I run out of steam or ideas, it would be awesome with a `0.4.0` release. Lots of new goodies in here now :)